### PR TITLE
Remove spectating delay

### DIFF
--- a/game/dota_addons/dotarun/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/dotarun/scripts/vscripts/addon_game_mode.lua
@@ -193,6 +193,9 @@ function CDotaRun:InitGameMode()
 
     GameRules:GetGameModeEntity():SetThink( "OnThink", self, 1 )
 
+    -- Remove spectating delay
+    Convars:SetInt('tv_delay', 0)
+
     print( "Dotarun has literally loaded." )
 end
 


### PR DESCRIPTION
Removes spectating delay so that anyone in the friendlist can watch the custom game live (current = default delay is 2 minutes)

Reference:
https://github.com/OpenAngelArena/oaa/pull/3154